### PR TITLE
Oppgrader cdn-upload GitHub Action lib til v2

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -33,11 +33,13 @@ jobs:
         run: "npm run build"
 
       - id: cdn-upload
-        uses: navikt/frontend/actions/cdn-upload/v1@main
+        uses: nais/deploy/actions/cdn-upload/v2@master
         with:
-          cdn-team-name: dusseldorf
+          team: dusseldorf
           source: ./dist/
           destination: "k9-innsyn-dine-pleiepenger-mikrofrontend"
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
       - name: Extract manifest url
         id: extract-manifest-url


### PR DESCRIPTION
Bygget feiler fordi vi ikke lenger kan bruke cdn-upload@v1 lenger – vi må oppgradere til v2.